### PR TITLE
Update rvi_sota_client commit for static deltas

### DIFF
--- a/meta-sota/recipes-sota/rvi-sota-client/rvi-sota-client_git.bb
+++ b/meta-sota/recipes-sota/rvi-sota-client/rvi-sota-client_git.bb
@@ -11,13 +11,13 @@ S = "${WORKDIR}/git"
 # When changing this, don't forget to:
 # 1) Update PV
 # 2) Check that Cargo.lock hasn't changed with git diff old..new Cargo.lock
-SRCREV = "d1a5d0f0024099d5feea403a9ec899a88ed36eff"
+SRCREV = "f42d0f93051bd34a33e2cbc76628392520e1c365"
 
 # Generate with:
 #   git describe --tags | cut -b2-
 # or from the rvi_sota_client repo:
 #   make package-version
-PV = "0.2.32-145-gd1a5d0f"
+PV = "0.2.32-149-gf42d0f9"
 
 BBCLASSEXTEND = "native"
 
@@ -27,7 +27,6 @@ FILES_${PN} = " \
                 ${bindir}/sota_client \
                 ${bindir}/sota_sysinfo.sh \
                 ${bindir}/system_info.sh \
-                ${bindir}/sota_ostree.sh \
                 ${bindir}/sota_prov.sh \
                 ${sysconfdir}/sota_client.version \
                 ${sysconfdir}/sota_certificates \
@@ -38,8 +37,9 @@ FILES_${PN} = " \
               "
 
 SRC_URI = " \
-crate://crates.io/aho-corasick/0.5.3 \
 crate://crates.io/aho-corasick/0.6.3 \
+crate://crates.io/backtrace/0.3.0 \
+crate://crates.io/backtrace-sys/0.1.10 \
 crate://crates.io/base64/0.4.1 \
 crate://crates.io/bit-set/0.4.0 \
 crate://crates.io/bit-vec/0.4.3 \
@@ -51,67 +51,68 @@ crate://crates.io/chan/0.1.19 \
 crate://crates.io/chan-signal/0.2.0 \
 crate://crates.io/chrono/0.3.0 \
 crate://crates.io/crossbeam/0.2.10 \
+crate://crates.io/dbghelp-sys/0.2.0 \
 crate://crates.io/dbus/0.5.2 \
 crate://crates.io/dtoa/0.4.1 \
 crate://crates.io/env_logger/0.4.2 \
+crate://crates.io/error-chain/0.10.0 \
 crate://crates.io/error-chain/0.7.2 \
+crate://crates.io/filetime/0.1.10 \
 crate://crates.io/foreign-types/0.2.0 \
 crate://crates.io/gcc/0.3.45 \
 crate://crates.io/gdi32-sys/0.2.0 \
 crate://crates.io/getopts/0.2.14 \
+crate://crates.io/hex/0.2.0 \
 crate://crates.io/httparse/1.2.1 \
-crate://crates.io/hyper/0.10.6 \
+crate://crates.io/hyper/0.10.8 \
 crate://crates.io/idna/0.1.1 \
 crate://crates.io/iovec/0.1.0 \
 crate://crates.io/itoa/0.3.1 \
 crate://crates.io/kernel32-sys/0.2.2 \
 crate://crates.io/language-tags/0.2.2 \
-crate://crates.io/lazy_static/0.2.6 \
+crate://crates.io/lazy_static/0.2.8 \
 crate://crates.io/libc/0.2.21 \
 crate://crates.io/log/0.3.7 \
 crate://crates.io/matches/0.1.4 \
-crate://crates.io/memchr/0.1.11 \
 crate://crates.io/memchr/1.0.1 \
 crate://crates.io/metadeps/1.1.1 \
 crate://crates.io/mime/0.2.3 \
 crate://crates.io/nom/1.2.4 \
 crate://crates.io/num/0.1.37 \
-crate://crates.io/num-integer/0.1.33 \
+crate://crates.io/num-integer/0.1.34 \
 crate://crates.io/num-iter/0.1.33 \
 crate://crates.io/num-traits/0.1.37 \
 crate://crates.io/num_cpus/1.3.0 \
 crate://crates.io/openssl/0.9.10 \
 crate://crates.io/openssl-sys/0.9.10 \
-crate://crates.io/pem/0.2.0 \
+crate://crates.io/pem/0.3.0 \
 crate://crates.io/pkg-config/0.3.9 \
 crate://crates.io/quote/0.3.15 \
 crate://crates.io/rand/0.3.15 \
 crate://crates.io/redox_syscall/0.1.17 \
-crate://crates.io/regex/0.1.80 \
 crate://crates.io/regex/0.2.1 \
-crate://crates.io/regex-syntax/0.3.9 \
 crate://crates.io/regex-syntax/0.4.0 \
 crate://crates.io/ring/0.7.1 \
 crate://crates.io/rust-crypto/0.2.36 \
+crate://crates.io/rustc-demangle/0.1.4 \
 crate://crates.io/rustc-serialize/0.3.23 \
 crate://crates.io/rustc_version/0.1.7 \
 crate://crates.io/semver/0.1.20 \
 crate://crates.io/serde/0.9.13 \
 crate://crates.io/serde_codegen_internals/0.14.2 \
 crate://crates.io/serde_derive/0.9.13 \
-crate://crates.io/serde_json/0.9.9 \
+crate://crates.io/serde_json/0.9.10 \
 crate://crates.io/sha1/0.2.0 \
 crate://crates.io/syn/0.11.10 \
 crate://crates.io/synom/0.11.3 \
-crate://crates.io/thread-id/2.0.0 \
+crate://crates.io/tar/0.4.11 \
 crate://crates.io/thread-id/3.0.0 \
-crate://crates.io/thread_local/0.2.7 \
 crate://crates.io/thread_local/0.3.3 \
 crate://crates.io/time/0.1.36 \
 crate://crates.io/toml/0.2.1 \
 crate://crates.io/toml/0.3.2 \
 crate://crates.io/traitobject/0.1.0 \
-crate://crates.io/tungstenite/0.1.1 \
+crate://crates.io/tungstenite/0.2.2 \
 crate://crates.io/typeable/0.1.2 \
 crate://crates.io/unicase/1.4.0 \
 crate://crates.io/unicode-bidi/0.2.5 \
@@ -123,12 +124,12 @@ crate://crates.io/untrusted/0.3.2 \
 crate://crates.io/url/1.4.0 \
 crate://crates.io/user32-sys/0.2.0 \
 crate://crates.io/utf-8/0.7.0 \
-crate://crates.io/utf8-ranges/0.1.3 \
 crate://crates.io/utf8-ranges/1.0.0 \
 crate://crates.io/uuid/0.4.0 \
 crate://crates.io/void/1.0.2 \
 crate://crates.io/winapi/0.2.8 \
 crate://crates.io/winapi-build/0.1.1 \
+crate://crates.io/xattr/0.1.11 \
 git://github.com/advancedtelematic/rvi_sota_client \
 "
 SRC_URI[index.md5sum] = "79f10f436dbf26737cc80445746f16b4"
@@ -161,7 +162,6 @@ do_install() {
   install -m 0755 target/${TARGET_SYS}/release/sota_client ${D}${bindir}
   install -m 0755 ${S}/run/sota_sysinfo.sh ${D}${bindir}
   ln -fs ${bindir}/sota_sysinfo.sh ${D}${bindir}/system_info.sh  # For compatibilty with old sota.toml files
-  install -m 0755 ${S}/run/sota_ostree.sh ${D}${bindir}
   install -m 0755 ${S}/run/sota_prov.sh ${D}${bindir}
   install -m 0755 ${S}/run/canonical_json.py ${D}${bindir}
 


### PR DESCRIPTION
Related to https://github.com/advancedtelematic/rvi_sota_client/pull/218.

FYI, the `sota-ostree.sh` script has been removed and all `ostree` commands are now called from the client.